### PR TITLE
Update index.ts  更新API地址

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -122,7 +122,7 @@ export function apply(ctx: Context, config: Config) {
       uploadFormData.append('files', await ctx.http.get(url, {responseType: 'blob'}))
       const hash = Date.now()
 
-      const path = (await ctx.http.post(`https://smilingwolf-wd-tagger.hf.space/upload?upload_id=${hash}`, uploadFormData))[0]
+      const path = (await ctx.http.post(`https://smilingwolf-wd-tagger.hf.space/gradio_api/upload?upload_id=${hash}`, uploadFormData))[0]
 
       let body = {
         "data": [
@@ -143,9 +143,9 @@ export function apply(ctx: Context, config: Config) {
         "session_hash": String(hash),
       }
 
-      await ctx.http.post("https://smilingwolf-wd-tagger.hf.space/queue/join", body)
+      await ctx.http.post("https://smilingwolf-wd-tagger.hf.space/gradio_api/queue/join", body)
 
-      const res = await ctx.http.get(`https://smilingwolf-wd-tagger.hf.space/queue/data?session_hash=${hash}`)
+      const res = await ctx.http.get(`https://smilingwolf-wd-tagger.hf.space/gradio_api/queue/data?session_hash=${hash}`)
       let data = JSON.parse(res.split("\n")[4].slice(5, res.split("\n")[4].length)).output.data
       
       let result =  `标签：\n${data[0]}\n\n角色：${data[2].label ?? "未知"}`


### PR DESCRIPTION
API地址变更
```
https://smilingwolf-wd-tagger.hf.space/
```
变更为
```
https://smilingwolf-wd-tagger.hf.space/gradio_api/
```


---


更改后不再出现 Not found 报错

否则，使用时会报错
```
2024-12-07 14:19:03 [W] command tagger.rec <img src="https://multimedia.nt.qq.com.cn/download?appid=1407&amp;fileid=EhT1I8l8xONYJy4o6CRILTY0lq4MKBin0AEg_woo-ZOP24GVigMyBHByb2RQgL2jAVoQlVp3fAUV-He3Kc0Biabulg&amp;spec=0&amp;rkey=CAMSKMa3OFokB_Tl1WsOpUqHEGvaogIjqrdeW61CkNb7xKSi0rlBR65haXM" file="B6FB181553E0E4D41B3CEBC332588CDF.jpg" sub-type="1" file-size="26663"/>
                        Error: Not Found
                            at [cordis.invoke] (D:\QQbots\QQ_bots\koishing\coding\koishi-a\koishi-app\node_modules\@cordisjs\plugin-http\lib\index.cjs:340:23)
                            at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
                            at async Proxy.<anonymous> (D:\QQbots\QQ_bots\koishing\coding\koishi-a\koishi-app\node_modules\@cordisjs\plugin-http\lib\index.cjs:184:26)
                            at async _Command.<anonymous> (D:\QQbots\QQ_bots\koishing\coding\koishi-a\koishi-app\external\koishi-shangxue-apps\plugins\waifu-diffusion-tagger\src\index.ts:125:21)
                            at async Array.<anonymous> (D:\QQbots\QQ_bots\koishing\coding\koishi-a\koishi-app\node_modules\@koishijs\core\src\command\command.ts:291:14)
                            at async _Command.execute (D:\QQbots\QQ_bots\koishing\coding\koishi-a\koishi-app\node_modules\@koishijs\core\src\command\command.ts:307:22)
                            at async <anonymous> (D:\QQbots\QQ_bots\koishing\coding\koishi-a\koishi-app\node_modules\@koishijs\core\src\session.ts:443:22)
                            at async Proxy.withScope (D:\QQbots\QQ_bots\koishing\coding\koishi-a\koishi-app\node_modules\@koishijs\core\src\session.ts:342:22)
                            at async next (D:\QQbots\QQ_bots\koishing\coding\koishi-a\koishi-app\node_modules\@koishijs\core\src\middleware.ts:258:16)
```

---
---
---


更新后可以使用

![image](https://github.com/user-attachments/assets/e2cffd58-5485-4f27-a7a3-c66d5936ed41)
